### PR TITLE
Added the Check RTT function to check if the device is live on network

### DIFF
--- a/app/src/main/java/org/lfedge/homeedge/client/APIImpl.java
+++ b/app/src/main/java/org/lfedge/homeedge/client/APIImpl.java
@@ -129,4 +129,19 @@ public class APIImpl {
         }
         return status;
     }
+    public String getPing(String url) throws InterruptedException {
+        String resp = null;
+        Call<String> call = Client.getInstance().getMyApi().getPing(url,url);
+
+        try {
+            retrofit2.Response<String> pingResponse = call.execute();
+            if(pingResponse.isSuccessful()){
+                Log.d(TAG,pingResponse.body().toString());
+                resp = pingResponse.body().toString();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return resp;
+    }
 }

--- a/app/src/main/java/org/lfedge/homeedge/client/Api.java
+++ b/app/src/main/java/org/lfedge/homeedge/client/Api.java
@@ -34,4 +34,6 @@ public interface Api {
     Call<Response.ScoreResponse> getScoreInfo(@Url String url,@Body JsonObject device, @Query("id") String deviceId);
     @POST
     Call<Response.ServiceResponse> ExecuteService(@Url String url,@Body JsonObject Servicedata, @Query("Object")ServiceInfo serviceInfo);
+    @GET
+    Call<String>getPing(@Url String url,@Query("url") String path);
 }

--- a/app/src/main/java/org/lfedge/homeedge/client/Client.java
+++ b/app/src/main/java/org/lfedge/homeedge/client/Client.java
@@ -17,6 +17,9 @@
 
 package org.lfedge.homeedge.client;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
 import org.lfedge.homeedge.common.Utils;
 
 import retrofit2.Retrofit;
@@ -27,8 +30,11 @@ public class Client {
     private final Api myApi;
 
     private Client() {
+        Gson gson = new GsonBuilder()
+                .setLenient()
+                .create();
         Retrofit retrofit = new Retrofit.Builder().baseUrl(Utils.BASE_URL)
-                .addConverterFactory(GsonConverterFactory.create())
+                .addConverterFactory(GsonConverterFactory.create(gson))
                 .build();
         myApi = retrofit.create(Api.class);
     }

--- a/app/src/main/java/org/lfedge/homeedge/common/RoundTripTime.java
+++ b/app/src/main/java/org/lfedge/homeedge/common/RoundTripTime.java
@@ -1,0 +1,51 @@
+package org.lfedge.homeedge.common;
+
+import android.content.Context;
+import android.util.Log;
+
+import org.lfedge.homeedge.client.APIImpl;
+import org.lfedge.homeedge.database.DeviceDao;
+import org.lfedge.homeedge.database.DeviceDatabase;
+import org.lfedge.homeedge.model.Device;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class RoundTripTime implements Runnable{
+    Context mContext;
+    public static final String TAG="RTT";
+    public RoundTripTime(Context mcontext){
+        this.mContext = mcontext;
+    }
+
+    @Override
+    public void run() {
+        DeviceDao deviceDao = DeviceDatabase.getDatabase(mContext).deviceDao();
+        List<Device> deviceList = deviceDao.getAllDevices();
+        Log.d(TAG,"Device List size is " +deviceList.size());
+        Iterator<Device> deviceIterator = deviceList.iterator();
+        while(deviceIterator.hasNext()) {
+            Device device = deviceIterator.next();
+            Log.d(TAG,"Device obtained is" +device.getEdge_orch_id());
+            Utils.setOrchestrationInfoAPI(device.getIp());
+            String targetURL = Utils.BASE_URL + Utils.API.PING_REQUEST;
+            APIImpl api = new APIImpl(mContext);
+            String response = null;
+            try {
+                int tryLimit = 12;
+                while(response==null && tryLimit>0){
+                    response = api.getPing(targetURL);
+                    tryLimit--;
+                    Thread.currentThread().sleep(5000);
+                }
+                if(response==null)
+                {   Log.d(TAG,"Deleting the device" +device.getEdge_orch_id());
+                    deviceDao.deleteDevice(device.getEdge_orch_id());
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
Description
RTT is used to continously ping to devices discovered by HE to get pong response. If HE fails to receive response from any particular device, then it waits for 12 retries and then finally deletes the device from the db.

Steps to check:
1. Launch the android HE
2. Start the Linux HE
3. Linux HE shall be discovered by Android HE

```
D/Utils: id : edge-orchestration-53b41e4c-bd9f-422a-aa4a-1adb71ef3c65
D/NsdHelper: The DeviceID generated is edge-orchestration-53b41e4c-bd9f-422a-aa4a-1adb71ef3c65
D/NsdHelper: Initialize NSD
D/NsdHelper: Calling Service Discovery
D/NsdHelper: Service discovery started
D/HomeEdgeService: Wifi states has changed
D/Utils: The IP resolved is 192.168.1.109
D/HomeEdgeService: Starting server
D/HTTPServer: Routes are added
D/HTTPServer: Setting the hostname as 192.168.1.109port to : 56001
D/HomeEdgeService: Staring the Server
D/HomeEdgeService: The Server is running on 192.168.1.109
D/HTTPServer: Routes are added
D/HTTPServer: Setting the hostname as 192.168.1.109port to : 56002
D/HomeEdgeService: Staring the Server
I/TcpOptimizer: [insertTCPSessionList] sid=101, g_tcpConnListCount=1
I/TcpOptimizer: [listen] sid=101, port=56002
I/TcpOptimizer: [deleteTCPSessionList] sid=101, g_tcpConnListCount=0
D/HomeEdgeService: The Server is running on 192.168.1.109
D/HomeEdgeService: Wifi states has changed
D/Utils: The IP resolved is 192.168.1.109
D/HomeEdgeService: HTTP Server is not null
D/HomeEdgeService: The IP now is 192.168.1.109
D/RTT: Device List size is 0
W/System: A resource failed to call close. 
W/System: A resource failed to call close. 
I/TcpOptimizer: [tcpStateMonitor] next... nSockets=1
I/TcpOptimizer: [tcpStateMonitor] Pause
D/RTT: Device List size is 0
D/RTT: Device List size is 0
D/RTT: Device List size is 0
D/RTT: Device List size is 0
D/RTT: Device List size is 0
D/RTT: Device List size is 0
D/RTT: Device List size is 0
D/RTT: Device List size is 0
D/NsdHelper: Service discovery successname: edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e, type: _orchestration._tcp., host: null, port: 0, txtRecord: 
D/NsdHelper: Resolving the service
D/NsdHelper: Resolve Succeeded. name: edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e, type: ._orchestration._tcp, host: /192.168.1.110, port: 42425, txtRecord:  AISER= Platform=docker ExecType=container
D/NsdHelper: Exectype:container
D/NsdHelper: Platform:docker
D/NsdHelper: Creating a device to insert in DB
I/lfedge.homeedg: Waiting for a blocking GC ClassLinker
D/NsdHelper: Calling Orchestration API
D/APIImpl: getOrchestrationInfo is getting called at http://192.168.1.110:56002/api/v1/discoverymgr/orchestrationinfo
```
4. Stop the Linux HE to see if it gets removed from the Android HE Db

```
D/RTT: Device List size is 1
D/RTT: Device obtained isedge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e
I/TcpOptimizer: Restarting tcpStateMonitor
I/TcpOptimizer: [insertTCPSessionList] sid=6, g_tcpConnListCount=1
I/TcpOptimizer: [tcpStateMonitor] Resume
I/TcpOptimizer: [updateIPandPort] (192.168.1.110_56002), sid=6
D/APIImpl: Pong

D/RTT: Device List size is 1
D/RTT: Device obtained isedge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e
W/System.err: java.net.ConnectException: Failed to connect to /192.168.1.110:56002
W/System.err:     at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:265)
W/System.err:     at okhttp3.internal.connection.RealConnection.connect(RealConnection.java:183)
W/System.err:     at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.java:224)
W/System.err:     at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.java:108)
W/System.err:     at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.java:88)
W/System.err:     at okhttp3.internal.connection.Transmitter.newExchange(Transmitter.java:169)
W/System.err:     at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:41)
W/System.err:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
W/System.err:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
W/System.err:     at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:94)
W/System.err:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
W/System.err:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
W/System.err:     at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93)
W/System.err:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
W/System.err:     at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:88)
W/System.err:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
W/System.err:     at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
W/System.err:     at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:229)
W/System.err:     at okhttp3.RealCall.execute(RealCall.java:81)
W/System.err:     at retrofit2.OkHttpCall.execute(OkHttpCall.java:204)
W/System.err:     at retrofit2.DefaultCallAdapterFactory$ExecutorCallbackCall.execute(DefaultCallAdapterFactory.java:108)
W/System.err:     at org.lfedge.homeedge.client.APIImpl.getPing(APIImpl.java:137)
W/System.err:     at org.lfedge.homeedge.common.RoundTripTime.run(RoundTripTime.java:37)
W/System.err:     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:462)
W/System.err:     at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:307)
W/System.err:     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:302)
W/System.err:     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
W/System.err:     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
W/System.err:     at java.lang.Thread.run(Thread.java:923)
W/System.err: Caused by: java.net.ConnectException: failed to connect to /192.168.1.110 (port 56002) from /192.168.1.109 (port 60612) after 10000ms: isConnected failed: ECONNREFUSED (Connection refused)
W/System.err:     at libcore.io.IoBridge.isConnected(IoBridge.java:287)
W/System.err:     at libcore.io.IoBridge.connectErrno(IoBridge.java:192)
W/System.err:     at libcore.io.IoBridge.connect(IoBridge.java:134)
W/System.err:     at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:142)
W/System.err:     at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:390)
W/System.err:     at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:230)
W/System.err:     at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:212)
W/System.err:     at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:436)
W/System.err:     at java.net.Socket.connect(Socket.java:621)
W/System.err:     at okhttp3.internal.platform.AndroidPlatform.connectSocket(AndroidPlatform.java:71)
W/System.err:     at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:263)
W/System.err: 	... 28 more
W/System.err: Caused by: android.system.ErrnoException: isConnected failed: ECONNREFUSED (Connection refused)
W/System.err:     at libcore.io.IoBridge.isConnected(IoBridge.java:274)
W/System.err: 	... 38 more

D/RTT: Deleting the deviceedge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e
D/RTT: Device List size is 0
```

