### PR TITLE
Resolving the crash issue when services are not present

### DIFF
--- a/app/src/main/java/org/lfedge/homeedge/client/APIImpl.java
+++ b/app/src/main/java/org/lfedge/homeedge/client/APIImpl.java
@@ -58,7 +58,7 @@ public class APIImpl {
                     Response.OrchestrationResponse device = response.body();
                     if(device!= null){
                     Log.d(TAG,"Device Platform: "+device.getPlatform() + " ExecutionType:"+device.getExecutionType());
-                        if(!device.getServiceList().isEmpty()) {
+                        if(device.getServiceList()!=null && !device.getServiceList().isEmpty()) {
                             Log.d(TAG,"Updating with service List");
                             DeviceDatabase.databaseWriterExecutor.execute(() -> DeviceDatabase.getDatabase(mContext).
                                     deviceDao().update(deviceID, device.getServiceList()));
@@ -84,7 +84,7 @@ public class APIImpl {
             JsonObject gsonObject = (JsonObject) jsonParser.parse(object.toString());
             Call<Response.ScoreResponse> call = Client.getInstance().getMyApi().getScoreInfo(url,gsonObject,deviceID);
             retrofit2.Response<Response.ScoreResponse> scoreResponse = call.execute();
-            if(scoreResponse.isSuccessful() && scoreResponse.body().getScore()!=null){
+            if(scoreResponse.isSuccessful() && scoreResponse.body()!=null && scoreResponse.body().getScore()!=null){
                 score = scoreResponse.body().getScore();
                 Log.d(TAG,"The score obtained is " + score);
 
@@ -113,12 +113,12 @@ public class APIImpl {
             Call<Response.ServiceResponse> call = Client.getInstance().getMyApi().ExecuteService(url,gsonObject, serviceInfo);
 
             retrofit2.Response<Response.ServiceResponse> serviceResponse = call.execute();
-            if(serviceResponse.isSuccessful() && serviceResponse.body().getStatus()!=null){
+            if(serviceResponse.isSuccessful() && serviceResponse.body()!=null && serviceResponse.body().getStatus()!=null){
                 Log.d(TAG,"Received the response!!!" +serviceResponse.body().getStatus());
                 status = serviceResponse.body().getStatus();
             }else{
                 Log.e(TAG,"Error in API call ");
-                if(serviceResponse.errorBody().toString()!=null)
+                if(serviceResponse.errorBody()!=null)
                     status = serviceResponse.errorBody().string();
                 else
                     status = Utils.RESPONSE.NULL_RESPONSE;


### PR DESCRIPTION
Signed-off-by: Nitu <nitu.gupta@samsung.com>
Description: When HE doesnt have any services, the app crashes. Issue https://github.com/lf-edge/edge-home-orchestration-android/issues/4

Solution: getServiceList was returning null in case of no services and hence was crashing. The issue was resolved by adding null check

Steps to check: 
1. Launch the android HE
2. Start the docker container for Linux HE with no services in machine. Clear if any folders in /var/edge-orchestration/apps folder
3. Linux HE gets detected in the Android HE and there is no crash

````
2022-10-11 11:18:31.749 11363-11363/org.lfedge.homeedge D/NsdHelper: The DeviceID generated is edge-orchestration-46b63165-93b7-4eb0-9ffd-c0bc334373bc
2022-10-11 11:18:31.749 11363-11363/org.lfedge.homeedge D/NsdHelper: Initialize NSD
2022-10-11 11:18:31.749 11363-12554/org.lfedge.homeedge D/NsdHelper: Calling Service Discovery
2022-10-11 11:18:31.750 11363-12553/org.lfedge.homeedge D/NsdHelper: Service discovery started
2022-10-11 11:18:37.635 11363-12553/org.lfedge.homeedge D/NsdHelper: Service discovery successname: edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e, type: _orchestration._tcp., host: null, port: 0, txtRecord: 
2022-10-11 11:18:37.635 11363-12553/org.lfedge.homeedge D/NsdHelper: Resolving the service
2022-10-11 11:18:37.644 11363-12553/org.lfedge.homeedge D/NsdHelper: Resolve Succeeded. name: edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e, type: ._orchestration._tcp, host: /192.168.1.110, port: 42425, txtRecord: Platform=dockerExecType=container
2022-10-11 11:18:37.644 11363-12553/org.lfedge.homeedge D/NsdHelper: Exectype:container
2022-10-11 11:18:37.644 11363-12553/org.lfedge.homeedge D/NsdHelper: Platform:docker
2022-10-11 11:18:37.674 11363-12553/org.lfedge.homeedge D/NsdHelper: Creating a device to insert in DB
2022-10-11 11:18:37.674 11363-12553/org.lfedge.homeedge D/NsdHelper: Calling Orchestration API
2022-10-11 11:18:37.675 11363-12553/org.lfedge.homeedge D/APIImpl: getOrchestrationInfo is getting called at http://192.168.1.110:56002/api/v1/discoverymgr/orchestrationinfo
2022-10-11 11:18:37.790 11363-11363/org.lfedge.homeedge D/APIImpl: OnResponse is calledhttp://192.168.1.110:56002/api/v1/discoverymgr/orchestrationinfo?id=edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e
2022-10-11 11:18:37.790 11363-11363/org.lfedge.homeedge D/APIImpl: Device Platform: docker ExecutionType:container
2022-10-11 11:31:10.335 11363-12553/org.lfedge.homeedge I/NsdHelper: Discovery stopped: _orchestration._tcp.
```

